### PR TITLE
Replace gcc with cc

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ TARGET_DIR = $(BUILD_DIR)/debug
 RELEASE_TARGET_DIR = $(BUILD_DIR)/release
 
 # compilation
-CC = gcc
+CC = cc
 CFLAGS = -Wall -Wextra -Wpedantic -Iinclude
 LIBS = -lm -lxcb -lxcb-randr
 

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 NAME = radshift
 
 # installation
-INSTALL_PREFIX = /usr/bin
+INSTALL_PREFIX = /usr/local/bin
 
 # directories
 SRC_DIR = src
@@ -13,8 +13,8 @@ RELEASE_TARGET_DIR = $(BUILD_DIR)/release
 
 # compilation
 CC = cc
-CFLAGS = -Wall -Wextra -Wpedantic -Iinclude
-LIBS = -lm -lxcb -lxcb-randr
+CFLAGS = -Wall -Wextra -Wpedantic -Iinclude -I/usr/X11R6/include
+LIBS = -lm -lxcb -lxcb-randr -L/usr/X11R6/lib
 
 # debug mode
 DBFLAGS = -Werror -Wshadow -Wstrict-overflow -fno-strict-aliasing -g -Og -DDEBUG

--- a/src/radshift.c
+++ b/src/radshift.c
@@ -133,7 +133,7 @@ int main(int argc, char **argv)
 	} else {
 		int temperature = atoi(argv[1]);
 		if (temperature < 2000 || temperature >= 10000) {
-			fprintf(stderr, "Using absurd temperature, aborting!");
+			fprintf(stderr, "Using absurd temperature, aborting!\n");
 			return EXIT_FAILURE;
 		}
 		rc = set_temperature(temperature);


### PR DESCRIPTION
I wanted to compile radshift on OpenBSD which doesn't use GCC but clang instead. Changing from gcc here to cc allows to compile radshift on non-GCC platforms (also affects FreeBSD) while still being able to compile on systems with GCC.