### PR TITLE
Add missing newline

### DIFF
--- a/src/radshift.c
+++ b/src/radshift.c
@@ -133,7 +133,7 @@ int main(int argc, char **argv)
 	} else {
 		int temperature = atoi(argv[1]);
 		if (temperature < 2000 || temperature >= 10000) {
-			fprintf(stderr, "Using absurd temperature, aborting!");
+			fprintf(stderr, "Using absurd temperature, aborting!\n");
 			return EXIT_FAILURE;
 		}
 		rc = set_temperature(temperature);


### PR DESCRIPTION
Add a newline when printing an error about absurd temperature.

```
$ ./radshift 10000K                                                                                                                                                                                                                                                                                                                                     
Using absurd temperature, aborting!$
```

Now it looks better:

```
$ ./radshift 10000K                                                                                                                                                                                                                                                                                                                                     
Using absurd temperature, aborting!
$
```