### PR TITLE
Replace gcc with cc in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ TARGET_DIR = $(BUILD_DIR)/debug
 RELEASE_TARGET_DIR = $(BUILD_DIR)/release
 
 # compilation
-CC = gcc
+CC = cc
 CFLAGS = -Wall -Wextra -Wpedantic -Iinclude
 LIBS = -lm -lxcb -lxcb-randr
 


### PR DESCRIPTION
I want to compile radshift on OpenBSD which doesn't use GCC but clang instead. Changing from gcc here to cc allows to compile radshift on non-GCC platforms (also affects FreeBSD) while still being able to compile on systems with GCC.