### PR TITLE
Support pledge on OpenBSD

### DIFF
--- a/src/radshift.c
+++ b/src/radshift.c
@@ -126,6 +126,13 @@ int main(int argc, char **argv)
 
 	int rc;
 
+#ifdef __OpenBSD__
+	if (pledge("stdio rpath unix", NULL) == -1) {
+		fprintf(stderr, "pledge\n");
+		return EXIT_FAILURE;
+	}
+#endif /* __OpenBSD__ */
+
 	if (strcmp(argv[1], "--auto") == 0) {
 		rc = auto_set();
 	} else if (strcmp(argv[1], "--continuous") == 0) {


### PR DESCRIPTION
Hi,

this adds support for [pledge](https://man.openbsd.org/pledge) on OpenBSD. It basically restricts the process to a subset of syscalls. I.e. the process will not be able to write files, connect to the network, etc.

Not sure if you accept such pull requests since this introduces ifdefs to the code. I am planning to package radshift for OpenBSD and could carry the patch downstream, however, upstream would be nicer :)

Cheers 